### PR TITLE
build: address mining on deployment script

### DIFF
--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -36,7 +36,7 @@ contract Deploy is Script, Utilities {
 
         // deploy oracle with 4 leading zeros
         oracle = deployWithLeadingZeros(deployer, 0, type(MockOracle).creationCode, 4); // nonce 1
-        
+
         // prepare bytecode for MarginAccount
         address optionTokenAddr = addressFrom(msg.sender, 3);
         // deploy MarginAccount
@@ -60,16 +60,15 @@ contract Deploy is Script, Utilities {
             bound := shl(pow, 2)
         }
         uint256 salt;
+        bytes32 codeHash = keccak256(creationCode);
+
         while (true) {
-            address prediction = Create2.computeAddress(bytes32(salt), keccak256(creationCode), address(deployer));
+            address prediction = Create2.computeAddress(bytes32(salt), codeHash , address(deployer));
             if (uint160(prediction) < bound) break;
             unchecked {
                 salt++;
             }
         }
-
-        console.log("salt found:", salt);
-        
         addr = deployer.deploy(value, creationCode, bytes32(salt));
     }
 }

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -3,28 +3,73 @@ pragma solidity =0.8.13;
 
 import "forge-std/Script.sol";
 
+import "openzeppelin/utils/Create2.sol";
+
 import "src/core/OptionToken.sol";
 import "src/core/L1/MarginAccount.sol";
 
 // todo: change to real oracle
 import "src/test/mocks/MockOracle.sol";
-
 import "src/test/utils/Utilities.sol";
 
+import { Create2Deployer } from "./utils.sol";
+
 contract Deploy is Script, Utilities {
-  function run () external {
-    vm.startBroadcast();
+    function run() external {
+        vm.startBroadcast();
 
-    deploy();
+        deploy();
 
-    vm.stopBroadcast();
-  }
+        vm.stopBroadcast();
+    }
 
-  function deploy() public returns (MockOracle oracle, OptionToken token, MarginAccount marginAccount)  {
-    oracle = new MockOracle();
+    function deploy()
+        public
+        returns (
+            address oracle,
+            address optionToken,
+            address marginAccount
+        )
+    {
+        // deploy deployer to use create2
+        Create2Deployer deployer = new Create2Deployer(); // nonce 0
 
-    address marginAccountAddr= addressFrom(msg.sender, 2);
-    token = new OptionToken(address(oracle), marginAccountAddr);
-    marginAccount = new MarginAccount(address(token));
-  }
+        // deploy oracle with 4 leading zeros
+        oracle = deployWithLeadingZeros(deployer, 0, type(MockOracle).creationCode, 4); // nonce 1
+        
+        // prepare bytecode for MarginAccount
+        address optionTokenAddr = addressFrom(msg.sender, 3);
+        // deploy MarginAccount
+        bytes memory maCreationCode = type(MarginAccount).creationCode;
+        bytes memory maBytecode = abi.encodePacked(maCreationCode, abi.encode(optionTokenAddr));
+        marginAccount = deployWithLeadingZeros(deployer, 0, maBytecode, 4); // nonce 2
+
+        // deploy optionToken directly, just so the address is the same as predicted by `create` (optionTokenAddr) 
+        optionToken = address(new OptionToken(oracle, marginAccount));
+    }   
+
+    function deployWithLeadingZeros(Create2Deployer deployer, uint256 value, bytes memory creationCode, uint8 zerosBytes) 
+        internal 
+        returns (address addr) 
+    {
+        uint8 pow = 160 - (zerosBytes * 4);
+        uint160 bound;
+
+        // solhint-disable-next-line
+        assembly {
+            bound := shl(pow, 2)
+        }
+        uint256 salt;
+        while (true) {
+            address prediction = Create2.computeAddress(bytes32(salt), keccak256(creationCode), address(deployer));
+            if (uint160(prediction) < bound) break;
+            unchecked {
+                salt++;
+            }
+        }
+
+        console.log("salt found:", salt);
+        
+        addr = deployer.deploy(value, creationCode, bytes32(salt));
+    }
 }

--- a/script/utils.sol
+++ b/script/utils.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity =0.8.13;
+
+import "forge-std/Script.sol";
+
+import "openzeppelin/utils/Create2.sol";
+
+contract Create2Deployer {
+    function deploy(uint256 value, bytes memory bytecode, bytes32 salt)
+        external
+        returns (address addr)
+    {
+        assembly {
+            addr := create2(value, add(bytecode, 0x20), mload(bytecode), salt)
+        }
+    }
+}

--- a/script/utils.sol
+++ b/script/utils.sol
@@ -10,6 +10,7 @@ contract Create2Deployer {
         external
         returns (address addr)
     {
+        // solhint-disable-next-line
         assembly {
             addr := create2(value, add(bytecode, 0x20), mload(bytecode), salt)
         }


### PR DESCRIPTION
## Feature:
Automatically find salts that generates addresses more leading 0s while deploying, which is cheaper to interact with.

### Constraints:
Forge script is currently counting gas on all computation within the script, which limits the ability to only find 4 leading errors in the address.

### Deployment script
```
forge script script/Deploy.sol --private-key {} --fork-url {}
```