### PR TITLE
Handle remove collateral if account has expired short (#109)

### DIFF
--- a/src/config/errors.sol
+++ b/src/config/errors.sol
@@ -75,6 +75,9 @@ error FM_SplitAmountMisMatch();
 /// @dev trying to collateralized the position with different collateral than specified in productId
 error FM_CollateraliMisMatch();
 
+/// @dev account contains a short that has expired
+error FM_ExpiredShortInAccount();
+
 // Advanced Margin and AdvancedMarginLib Errors
 
 /// @dev account is not healthy / account is underwater
@@ -109,6 +112,9 @@ error AM_AccountIsNotEmpty();
 
 /// @dev amounts to repay in liquidation are not valid. Missing call, put or not proportional to the amount in subaccount.
 error AM_WrongRepayAmounts();
+
+/// @dev account contains a short that has expired
+error AM_ExpiredShortInAccount();
 
 // OptionToken
 

--- a/src/core/engines/advanced-margin/AdvancedMarginEngine.sol
+++ b/src/core/engines/advanced-margin/AdvancedMarginEngine.sol
@@ -332,7 +332,18 @@ contract AdvancedMarginEngine is BaseEngine, IMarginEngine, Ownable, ReentrancyG
     ) internal {
         // decode parameters
         (uint80 amount, address recipient, uint8 collateralId) = abi.decode(_data, (uint80, address, uint8));
-
+        // check if there is an expired short still in the account, if there is then collateral cant be removed
+        // until the position is settled
+        if (_account.shortCallAmount > 0) {
+            (,, uint64 expiry,,) = TokenIdUtil.parseTokenId(_account.shortCallId);
+            if (expiry < block.timestamp) revert AM_ExpiredShortInAccount();
+            // TODO: maybe settle here instead of reverting
+        }
+        if (_account.shortPutAmount > 0) {
+                        (,, uint64 expiry,,) = TokenIdUtil.parseTokenId(_account.shortPutId);
+            if (expiry < block.timestamp) revert AM_ExpiredShortInAccount();
+            // TODO: maybe settle here instead of reverting
+        }
         // update the account in memory
         _account.removeCollateral(amount, collateralId);
 

--- a/src/core/engines/full-margin/FullMarginEngine.sol
+++ b/src/core/engines/full-margin/FullMarginEngine.sol
@@ -185,7 +185,13 @@ contract FullMarginEngine is IMarginEngine, ReentrancyGuard, BaseEngine {
     ) internal {
         // decode parameters
         (uint80 amount, address recipient, uint8 collateralId) = abi.decode(_data, (uint80, address, uint8));
-
+        // check if there is an expired short still in the account, if there is then collateral cant be removed
+        // until the position is settled
+        if (_account.shortAmount > 0) {
+            (,, uint64 expiry,,) = TokenIdUtil.parseTokenId(_account.tokenId);
+            if (expiry < block.timestamp) revert FM_ExpiredShortInAccount();
+            // TODO: maybe settle here instead of reverting
+        }
         // update the account in memory
         _account.removeCollateral(amount, collateralId);
 


### PR DESCRIPTION
Responding to Issue #109. Solution here reverts the remove collateral if there is an expired short position, a better solution could be to settle the expired option automatically if an attempt to remove collateral was made as presumably the user would rather do that. I think the second solution is worth doing @antoncoding 