### PR TITLE
refactor: extracting debit spreads from BaseEngine

### DIFF
--- a/src/core/Grappa.sol
+++ b/src/core/Grappa.sol
@@ -46,7 +46,7 @@ contract Grappa is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeab
     IOptionToken public immutable optionToken;
 
     /*///////////////////////////////////////////////////////////////
-                         State Variables V1 
+                         State Variables V1
     //////////////////////////////////////////////////////////////*/
 
     /// @dev next id used to represent an address

--- a/src/core/engines/BaseEngine.sol
+++ b/src/core/engines/BaseEngine.sol
@@ -52,10 +52,6 @@ abstract contract BaseEngine {
 
     event OptionTokenBurned(address subAccount, uint256 tokenId, uint256 amount);
 
-    event OptionTokenMerged(address subAccount, uint256 longToken, uint256 shortToken, uint64 amount);
-
-    event OptionTokenSplit(address subAccount, uint256 spreadId, uint64 amount);
-
     event OptionTokenAdded(address subAccount, uint256 tokenId, uint64 amount);
 
     event OptionTokenRemoved(address subAccount, uint256 tokenId, uint64 amount);
@@ -311,50 +307,6 @@ abstract contract BaseEngine {
     }
 
     /**
-     * @dev burn option token and change the short position to spread. This will reduce collateral requirement
-            the option has to be provided by either caller, or the primary owner of subaccount
-     * @param _data bytes data to decode
-     */
-    function _merge(address _subAccount, bytes calldata _data) internal virtual {
-        // decode parameters
-        (uint256 longTokenId, uint256 shortTokenId, address from, uint64 amount) = abi.decode(
-            _data,
-            (uint256, uint256, address, uint64)
-        );
-
-        // token being burn must come from caller or the primary account for this subAccount
-        if (from != msg.sender && !_isPrimaryAccountFor(from, _subAccount)) revert BM_InvalidFromAddress();
-
-        _verifyMergeTokenIds(longTokenId, shortTokenId);
-
-        // update the account in state
-        _mergeLongIntoSpread(_subAccount, shortTokenId, longTokenId, amount);
-
-        emit OptionTokenMerged(_subAccount, longTokenId, shortTokenId, amount);
-
-        // this line will revert if usre is trying to burn an un-authrized tokenId
-        optionToken.burn(from, longTokenId, amount);
-    }
-
-    /**
-     * @dev Change existing spread position to short, and mint option token for recipient
-     * @param _subAccount subaccount that will be update in place
-     */
-    function _split(address _subAccount, bytes calldata _data) internal virtual {
-        // decode parameters
-        (uint256 spreadId, uint64 amount, address recipient) = abi.decode(_data, (uint256, uint64, address));
-
-        uint256 tokenId = _verifySpreadIdAndGetLong(spreadId);
-
-        // update the account in state
-        _splitSpreadInAccount(_subAccount, spreadId, amount);
-
-        emit OptionTokenSplit(_subAccount, spreadId, amount);
-
-        optionToken.mint(recipient, tokenId, amount);
-    }
-
-    /**
      * @notice  settle the margin account at expiry
      * @dev     this update the account storage
      */
@@ -406,19 +358,6 @@ abstract contract BaseEngine {
     function _decreaseLongInAccount(
         address _subAccount,
         uint256 tokenId,
-        uint64 amount
-    ) internal virtual {}
-
-    function _mergeLongIntoSpread(
-        address _subAccount,
-        uint256 shortTokenId,
-        uint256 longTokenId,
-        uint64 amount
-    ) internal virtual {}
-
-    function _splitSpreadInAccount(
-        address _subAccount,
-        uint256 spreadId,
         uint64 amount
     ) internal virtual {}
 
@@ -474,42 +413,5 @@ abstract contract BaseEngine {
      */
     function _isPrimaryAccountFor(address _primary, address _subAccount) internal pure returns (bool) {
         return (uint160(_primary) | 0xFF) == (uint160(_subAccount) | 0xFF);
-    }
-
-    /** ========================================================= **
-                Internal Functions for tokenId verification
-     ** ========================================================= **/
-
-    /**
-     * @dev make sure the user can merge 2 tokens (1 long and 1 short) into a spread
-     * @param longId id of the incoming token to be merged
-     * @param shortId id of the existing short position
-     */
-    function _verifyMergeTokenIds(uint256 longId, uint256 shortId) internal pure {
-        // get token attribute for incoming token
-        (TokenType longType, uint40 productId, uint64 expiry, uint64 longStrike, ) = longId.parseTokenId();
-
-        // token being added can only be call or put
-        if (longType != TokenType.CALL && longType != TokenType.PUT) revert BM_CannotMergeSpread();
-
-        (TokenType shortType, uint40 productId_, uint64 expiry_, uint64 shortStrike, ) = shortId.parseTokenId();
-
-        // check that the merging token (long) has the same property as existing short
-        if (shortType != longType) revert BM_MergeTypeMismatch();
-        if (productId_ != productId) revert BM_MergeProductMismatch();
-        if (expiry_ != expiry) revert BM_MergeExpiryMismatch();
-
-        // should use burn instead
-        if (longStrike == shortStrike) revert BM_MergeWithSameStrike();
-    }
-
-    function _verifySpreadIdAndGetLong(uint256 _spreadId) internal pure returns (uint256 longId) {
-        // parse the passed in spread id
-        (TokenType spreadType, uint40 productId, uint64 expiry, , uint64 shortStrike) = _spreadId.parseTokenId();
-
-        if (spreadType != TokenType.CALL_SPREAD && spreadType != TokenType.PUT_SPREAD) revert BM_CanOnlySplitSpread();
-
-        TokenType newType = spreadType == TokenType.CALL_SPREAD ? TokenType.CALL : TokenType.PUT;
-        longId = TokenIdUtil.formatTokenId(newType, productId, expiry, shortStrike, 0);
     }
 }

--- a/src/core/engines/advanced-margin/AdvancedMarginEngine.sol
+++ b/src/core/engines/advanced-margin/AdvancedMarginEngine.sol
@@ -10,6 +10,7 @@ import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
 // inheriting contracts
 import {BaseEngine} from "../BaseEngine.sol";
+import {DebitSpread} from "../mixins/DebitSpread.sol";
 import {SafeCast} from "openzeppelin/utils/math/SafeCast.sol";
 
 // interfaces
@@ -39,7 +40,7 @@ import "../../../config/errors.sol";
             Interacts with Oracle to read spot
             Interacts with VolOracle to read vol
  */
-contract AdvancedMarginEngine is IMarginEngine, BaseEngine, Ownable, ReentrancyGuard {
+contract AdvancedMarginEngine is IMarginEngine, BaseEngine, DebitSpread, Ownable, ReentrancyGuard {
     using AdvancedMarginMath for AdvancedMarginDetail;
     using AdvancedMarginLib for AdvancedMarginAccount;
     using SafeERC20 for IERC20;

--- a/src/core/engines/full-margin/FullMarginEngine.sol
+++ b/src/core/engines/full-margin/FullMarginEngine.sol
@@ -6,6 +6,7 @@ import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
 
 // inheriting contracts
 import {BaseEngine} from "../BaseEngine.sol";
+import {DebitSpread} from "../mixins/DebitSpread.sol";
 import {SafeCast} from "openzeppelin/utils/math/SafeCast.sol";
 
 // interfaces
@@ -34,7 +35,7 @@ import "../../../config/errors.sol";
             Interacts with OptionToken to mint / burn
             Interacts with grappa to fetch registered asset info
  */
-contract FullMarginEngine is BaseEngine, IMarginEngine, ReentrancyGuard {
+contract FullMarginEngine is BaseEngine, DebitSpread, IMarginEngine, ReentrancyGuard {
     using FullMarginLib for FullMarginAccount;
     using FullMarginMath for FullMarginDetail;
     using TokenIdUtil for uint256;

--- a/src/core/engines/mixins/DebitSpread.sol
+++ b/src/core/engines/mixins/DebitSpread.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// inheriting contracts
+import {BaseEngine} from "../BaseEngine.sol";
+
+// librarise
+import {TokenIdUtil} from "../../../libraries/TokenIdUtil.sol";
+
+// // constants and types
+import "../../../config/enums.sol";
+import "../../../config/errors.sol";
+
+/**
+ * @title   DebitSpread
+ * @author  @antoncoding, @dsshap
+ * @notice  util functions for MarginEngines to support debit spreads
+ */
+abstract contract DebitSpread is BaseEngine {
+    using TokenIdUtil for uint256;
+
+    event OptionTokenMerged(address subAccount, uint256 longToken, uint256 shortToken, uint64 amount);
+
+    event OptionTokenSplit(address subAccount, uint256 spreadId, uint64 amount);
+
+    /** ========================================================= **
+                   Internal Functions For Each Action
+     ** ========================================================= **/
+
+    /**
+     * @dev burn option token and change the short position to spread. This will reduce collateral requirement
+            the option has to be provided by either caller, or the primary owner of subaccount
+     * @param _data bytes data to decode
+     */
+    function _merge(address _subAccount, bytes calldata _data) internal virtual {
+        // decode parameters
+        (uint256 longTokenId, uint256 shortTokenId, address from, uint64 amount) = abi.decode(
+            _data,
+            (uint256, uint256, address, uint64)
+        );
+
+        // token being burn must come from caller or the primary account for this subAccount
+        if (from != msg.sender && !_isPrimaryAccountFor(from, _subAccount)) revert BM_InvalidFromAddress();
+
+        _verifyMergeTokenIds(longTokenId, shortTokenId);
+
+        // update the account in state
+        _mergeLongIntoSpread(_subAccount, shortTokenId, longTokenId, amount);
+
+        emit OptionTokenMerged(_subAccount, longTokenId, shortTokenId, amount);
+
+        // this line will revert if usre is trying to burn an un-authrized tokenId
+        optionToken.burn(from, longTokenId, amount);
+    }
+
+    /**
+     * @dev Change existing spread position to short, and mint option token for recipient
+     * @param _subAccount subaccount that will be update in place
+     */
+    function _split(address _subAccount, bytes calldata _data) internal virtual {
+        // decode parameters
+        (uint256 spreadId, uint64 amount, address recipient) = abi.decode(_data, (uint256, uint64, address));
+
+        uint256 tokenId = _verifySpreadIdAndGetLong(spreadId);
+
+        // update the account in state
+        _splitSpreadInAccount(_subAccount, spreadId, amount);
+
+        emit OptionTokenSplit(_subAccount, spreadId, amount);
+
+        optionToken.mint(recipient, tokenId, amount);
+    }
+
+    /** ========================================================= **
+                   State changing functions to override
+     ** ========================================================= **/
+
+    function _mergeLongIntoSpread(
+        address _subAccount,
+        uint256 shortTokenId,
+        uint256 longTokenId,
+        uint64 amount
+    ) internal virtual {}
+
+    function _splitSpreadInAccount(
+        address _subAccount,
+        uint256 spreadId,
+        uint64 amount
+    ) internal virtual {}
+
+    /** ========================================================= **
+                Internal Functions for tokenId verification
+     ** ========================================================= **/
+
+    /**
+     * @dev make sure the user can merge 2 tokens (1 long and 1 short) into a spread
+     * @param longId id of the incoming token to be merged
+     * @param shortId id of the existing short position
+     */
+    function _verifyMergeTokenIds(uint256 longId, uint256 shortId) internal pure {
+        // get token attribute for incoming token
+        (TokenType longType, uint40 productId, uint64 expiry, uint64 longStrike, ) = longId.parseTokenId();
+
+        // token being added can only be call or put
+        if (longType != TokenType.CALL && longType != TokenType.PUT) revert BM_CannotMergeSpread();
+
+        (TokenType shortType, uint40 productId_, uint64 expiry_, uint64 shortStrike, ) = shortId.parseTokenId();
+
+        // check that the merging token (long) has the same property as existing short
+        if (shortType != longType) revert BM_MergeTypeMismatch();
+        if (productId_ != productId) revert BM_MergeProductMismatch();
+        if (expiry_ != expiry) revert BM_MergeExpiryMismatch();
+
+        // should use burn instead
+        if (longStrike == shortStrike) revert BM_MergeWithSameStrike();
+    }
+
+    function _verifySpreadIdAndGetLong(uint256 _spreadId) internal pure returns (uint256 longId) {
+        // parse the passed in spread id
+        (TokenType spreadType, uint40 productId, uint64 expiry, , uint64 shortStrike) = _spreadId.parseTokenId();
+
+        if (spreadType != TokenType.CALL_SPREAD && spreadType != TokenType.PUT_SPREAD) revert BM_CanOnlySplitSpread();
+
+        TokenType newType = spreadType == TokenType.CALL_SPREAD ? TokenType.CALL : TokenType.PUT;
+        longId = TokenIdUtil.formatTokenId(newType, productId, expiry, shortStrike, 0);
+    }
+}

--- a/src/test/mocks/MockEngine.sol
+++ b/src/test/mocks/MockEngine.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 
 import {IMarginEngine} from "../../interfaces/IMarginEngine.sol";
 import {BaseEngine} from "../../core/engines/BaseEngine.sol";
+import {DebitSpread} from "../../core/engines/mixins/DebitSpread.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
@@ -17,7 +18,7 @@ import "../../config/errors.sol";
  * @title   MockEngine
  * @notice  Implement execute to test all flow in BaseEngine
  */
-contract MockEngine is BaseEngine, ReentrancyGuard {
+contract MockEngine is BaseEngine, DebitSpread, ReentrancyGuard {
     bool public isAboveWater;
 
     uint80 public mockPayout;


### PR DESCRIPTION
moving debit spread capability into an abstract contract. Engines that want this support can cherry pick it.